### PR TITLE
Adjust the casing of tmpdir to avoid the deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var spawn = require('child_process').spawn
   , path = require('path')
-  , tmpDir = require('os').tmpDir()
+  , tmpDir = require('os').tmpdir()
   , idgen = require('idgen')
   , fs = require('fs')
 


### PR DESCRIPTION
Fixes #2 